### PR TITLE
Pull_request_one

### DIFF
--- a/handlers/callback_handlers.py
+++ b/handlers/callback_handlers.py
@@ -288,7 +288,7 @@ async def process_starting_general(callback: types.CallbackQuery, state: FSMCont
         
 @router.callback_query(Admin_states.registration_process)
 async def process_admin(callback: types.CallbackQuery, state: FSMContext) -> None:
-    
+    page_value = 1
     '''
     Обработка запросов от inline-кнопок admin-a
     '''
@@ -322,10 +322,11 @@ async def process_admin(callback: types.CallbackQuery, state: FSMContext) -> Non
         form_info_list, user_info_list = info_tuple[0], info_tuple[1]
         information_panel = f"""Название субъекта: {form_info_list[2]},\nДолжность: {form_info_list[3]},\nМесто работы(организация): {form_info_list[4]},\nДата регистрации: {form_info_list[5]}"""
         await callback.message.edit_text(text=information_panel, reply_markup=Admin_Keyboards.reg_process_keyboard(form_info_list[1], user_info_list[0]).as_markup())
-    elif callback.data == 'check_reg':
-        await callback.message.edit_text(text="Выберете заявку из предложенных. Если нету кнопок, прикрепленных к данному сообщению, то заявки не сформировались - вернитесь к данному меню позже", reply_markup=Admin_Keyboards.application_gen(await db.get_unregistered()).as_markup())
-
-@router.callback_query(Admin_states.post_publication)
+    elif callback_data == 'check_reg':
+        await callback.message.edit_text(text="Выберете заявку из предложенных. Если нету кнопок, прикрепленных к данному сообщению, то заявки не сформировались - вернитесь к данному меню позже", reply_markup=Admin_Keyboards.application_gen(page_value=page_value, unreg_tuple=await db.get_unregistered()).as_markup())
+    elif "next_page" in callback_data or "prev_page" in callback_data:
+        page_value = callback_data.split(":") ; page_value = int(page_value[1])
+        await callback.message.edit_text(text="Выберете заявку из предложенных. Если нету кнопок, прикрепленных к данному сообщению, то заявки не сформировались - вернитесь к данному меню позже", reply_markup=Admin_Keyboards.application_gen(page_value=page_value, unreg_tuple=await db.get_unregistered(passed_values=10*page_value, available_values=(10*page_value)+10)).as_markup())
 async def process_open_chat_publication(callback: types.CallbackQuery, state: FSMContext) -> None:
     '''
     Обработка публикации в открытом канале
@@ -504,7 +505,7 @@ async def process_user(callback: types.CallbackQuery, state: FSMContext) -> None
         except UnboundLocalError:
             pass
     elif callback.data == 'check_reg':
-        await callback.message.edit_text(text="Выберете заявку из предложенных. Если нету кнопок, прикрепленных к данному сообщению, то заявки не сформировались - вернитесь к данному меню позже", reply_markup=Admin_Keyboards.application_gen(await db.get_unregistered()).as_markup())
+        await callback.message.edit_text(text="Выберете заявку из предложенных. Если нету кнопок, прикрепленных к данному сообщению, то заявки не сформировались - вернитесь к данному меню позже", reply_markup=Admin_Keyboards.application_gen(page_value=1, unreg_tuple=await db.get_unregistered()).as_markup())
         await state.set_state(Admin_states.registration_process)
     elif callback.data == 'publications':
         publications = await db.get_posts_to_public()

--- a/keyboards.py
+++ b/keyboards.py
@@ -192,20 +192,50 @@ class Admin_Keyboards():
 
         return admin_registrator_keyboard
     
-    def application_gen(unreg_tuple):
+    def application_gen(unreg_tuple, page_value: int):
 
         '''
             Отдельная функция, генерирующая кнопки, в з-ти от заявок пользователей
             Может быть аргументом reply_markup
         '''
-        unique_keys, registration_forms = unreg_tuple[0], unreg_tuple[1]
-        generated_keyboard = InlineKeyboardBuilder()
-        buttons_data = [InlineKeyboardButton(text=f'Пользователь из {registration_forms[i][6]}', callback_data=f"generated_button&uk:{unique_keys[i][0]}&datetime:{registration_forms[i][5]}") for i in range(len(registration_forms))]
-        generated_keyboard.add(*[elem for elem in buttons_data])
-        generated_keyboard.adjust(3, repeat=True)
 
-        return generated_keyboard
+        if page_value == 1 and len(unreg_tuple) == 10:
+            unique_keys, registration_forms = unreg_tuple[0], unreg_tuple[1]
+            generated_keyboard = InlineKeyboardBuilder()
+            buttons_data = [InlineKeyboardButton(text=f'Пользователь из {registration_forms[i][6]}', callback_data=f"generated_button&uk:{unique_keys[i][0]}&datetime:{registration_forms[i][5]}") for i in range(len(registration_forms))]
+            next_page = InlineKeyboardButton(text="Следующая страница", callback_data=f"next_page:{page_value + 1}")
+            generated_keyboard.add(*[elem for elem in buttons_data], next_page)
+            generated_keyboard.adjust(1, repeat=True)
+
+            return generated_keyboard
+        elif page_value == 1 and len(unreg_tuple) < 10:
+            unique_keys, registration_forms = unreg_tuple[0], unreg_tuple[1]
+            generated_keyboard = InlineKeyboardBuilder()
+            buttons_data = [InlineKeyboardButton(text=f'Пользователь из {registration_forms[i][6]}', callback_data=f"generated_button&uk:{unique_keys[i][0]}&datetime:{registration_forms[i][5]}") for i in range(len(registration_forms))]
+            generated_keyboard.add(*[elem for elem in buttons_data])
+            generated_keyboard.adjust(1, repeat=True)
+
+            return generated_keyboard
+        elif page_value > 1 and len(unreg_tuple) < 10:
+            unique_keys, registration_forms = unreg_tuple[0], unreg_tuple[1]
+            generated_keyboard = InlineKeyboardBuilder()
+            buttons_data = [InlineKeyboardButton(text=f'Пользователь из {registration_forms[i][6]}', callback_data=f"generated_button&uk:{unique_keys[i][0]}&datetime:{registration_forms[i][5]}") for i in range(len(registration_forms))]
+            prev_page = InlineKeyboardButton(text="Предыдущая страница", callback_data=f"prev_page:{page_value - 1}")
+            generated_keyboard.add(*[elem for elem in buttons_data], prev_page)
+            generated_keyboard.adjust(1, repeat=True)
     
+            return generated_keyboard
+        else:
+            unique_keys, registration_forms = unreg_tuple[0], unreg_tuple[1]
+            generated_keyboard = InlineKeyboardBuilder()
+            buttons_data = [InlineKeyboardButton(text=f'Пользователь из {registration_forms[i][6]}', callback_data=f"generated_button&uk:{unique_keys[i][0]}&datetime:{registration_forms[i][5]}") for i in range(len(registration_forms))]
+            next_page = InlineKeyboardButton(text="Следующая страница", callback_data=f"next_page:{page_value + 1}")
+            prev_page = InlineKeyboardButton(text="Предыдущая страница", callback_data=f"prev_page:{page_value - 1}")
+            generated_keyboard.add(*[elem for elem in buttons_data], next_page, prev_page)
+            generated_keyboard.adjust(1, repeat=True)
+    
+            return generated_keyboard
+
     def post_publication(post_id: int, pub_type: str = 'text') -> InlineKeyboardBuilder:
         '''
         Клавиатура для выбора публикации в открытом канале


### PR DESCRIPTION
     Планируется, что счет по страницам будет идти внутри callback_data:
        callback_data=f"next_page:{page_value + 1}" - если следующая страница
        callback_data=f"next_page:{page_value - 1}" - если предыдущая страница 
        соответсвтенно значение page_value будет принимать страницу в з-ти от коллбека.
        Вывод элементов будет строго 12 элементов, из которых 10 - заявки, а остальная кнопки "Следующая страница" или "Предыдущая страница"
        Если будет меньше 10 элементов на вывод и будет страница равна единице, то кнопок по перелистыванию страниц не будет
        Если будет ровно 10 элементов на вывод и будет страница равна единице, то будет кнопка "Следующая страница"
        Если будет меньше 10 элементов на вывод и будет страница больше единицы, то будет кнопка "Предыдущая страница"
        Во всех остальных случаях клавиатура содержит все кнопки
        Больше 12 элементов не может быть в одной клавиатуре, это обрабатывается следующим условием\
         if len(user_reg_forms) >= 10:  
                if available_values > len(user_reg_forms):
                    available_values = user_reg_forms
        ...
         return users_rows, user_reg_forms[passed_values:available_values + 1]
        где passed_values всегда на 10 единиц меньше available_values и никак не может превышать 
        len(user_reg_forms) т.к. passed_values зависит от available_values